### PR TITLE
Bugfix: Update Equip spec queries for parentEquips/childEquips

### DIFF
--- a/src/xeto/ph/entities.xeto
+++ b/src/xeto/ph/entities.xeto
@@ -328,9 +328,9 @@ Equip: Entity <abstract> {
   siteRef:      Ref
   spaceRef:     Ref?
   systemRef:    MultiRef?
-  parentEquips: Query<of:Point, via:"equipRef+">                  // Parent equips that contain this point
-  childEquips:  Query<of:Point, inverse:"ph::Equip.parentEquips"> // Sub-equips contained by this equip
-  points:       Query<of:Point, inverse:"ph::Point.equips">       // Points contained by this equip
+  parentEquips: Query<of:Equip, via:"equipRef+">                  // Parent equips that contain this point
+  childEquips:  Query<of:Equip, inverse:"ph::Equip.parentEquips"> // Sub-equips contained by this equip
+  points:       Query<of:Point, inverse:"ph::Point.parentEquips"> // Points contained by this equip
 }
 
 // Moving staircase used to move people between floors.
@@ -678,7 +678,7 @@ Point: Entity <abstract> {
   tz:            TimeZone?
   unit:          Unit?
   writable:      Marker?
-  equips:        Query<of:Equip, via:"equipRef+">  // Parent equips that contain this point
+  parentEquips:  Query<of:Equip, via:"equipRef+">  // Parent equips that contain this point
 }
 
 // Motor used with a pump to move fluid.


### PR DESCRIPTION
Found a bug in the Equip spec.  The parentEquips and childEquips queries were setup to query points rather than equips.

Also updated the variable name to be more consistent on the point spec. Both equip and point spec use the same 'parentEquips' naming for the query.