### PR TITLE
feat: add SpecFlavor enum to xeto sys types for documentation categor…

### DIFF
--- a/src/xeto/sys/types.xeto
+++ b/src/xeto/sys/types.xeto
@@ -92,6 +92,15 @@ SpanMode: Enum {
   pastYear     // Past 365 days including today
 }
 
+// Specification flavor enumeration
+SpecFlavor: Enum {
+  type     // Top level type
+  global   // Top level global slot spec
+  func     // Top level function spec
+  meta     // Top level meta spec
+  slot     // Slot spec under a parent
+}
+
 // Closed enumerated set of string values
 Enum: Scalar
 
@@ -156,4 +165,3 @@ Interface: Dict
 
 // BuildVar is string macro from "build.props" injected at build time
 BuildVar: Scalar
-


### PR DESCRIPTION
…ization

Added SpecFlavor enum with values: type, global, func, meta, slot to support semantic categorization of spec references in XetoDoc markdown processing. This enum enables the backtick normalization system to tag resolved specs with their flavor type for enhanced HTML rendering and frontend integration.

Note: Consider whether SpecFlavor is the appropriate enum name and if the current values are complete. Should "instance" be included as a SpecFlavor value? Also need to verify if "slot" is conceptually correct as a spec flavor, or if it represents something different in the Xeto type system.

Changes:
- Added SpecFlavor enum to xeto/src/xeto/sys/types.xeto
- Enum supports the backtick normalization format: `qname | SpecFlavor::flavor`
- Enables semantic HTML generation with specFlavor attributes