### PR TITLE
Add water flow and pressure points for hydronic systems - Updated Entering/Leaving naming standards

### DIFF
--- a/src/xeto/ph.points/water-flow.xeto
+++ b/src/xeto/ph.points/water-flow.xeto
@@ -29,3 +29,22 @@ DomesticWaterFlowSensor : WaterFlowSensor { domestic }
 // Setpoint for volumetric flow of domestic water
 DomesticWaterFlowSp : WaterFlowSp { domestic }
 
+//////////////////////////////////////////////////////////////////////////
+// Chilled Water
+//////////////////////////////////////////////////////////////////////////
+
+// Sensor for volumetric flow of chilled water
+ChilledWaterFlowSensor : WaterFlowSensor { chilled }
+
+// Setpoint for volumetric flow of chilled water
+ChilledWaterFlowSp : WaterFlowSp { chilled }
+
+//////////////////////////////////////////////////////////////////////////
+// Hot Water
+//////////////////////////////////////////////////////////////////////////
+
+// Sensor for volumetric flow of hot water
+HotWaterFlowSensor : WaterFlowSensor { hot }
+
+// Setpoint for volumetric flow of hot water
+HotWaterFlowSp : WaterFlowSp { hot }

--- a/src/xeto/ph.points/water-pressure.xeto
+++ b/src/xeto/ph.points/water-pressure.xeto
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2025, Project-Haystack
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   5 Jan 2025 Creation - Water pressure points from community documentation
+//
+
+// Point associated with water pressure
+WaterPressurePoint : NumberPoint <abstract> {
+  water
+  pressure
+  unit: Unit <quantity:"pressure"> "psi"
+}
+
+// Sensor for water pressure
+WaterPressureSensor : WaterPressurePoint & SensorPoint <abstract>
+
+// Setpoint for water pressure
+WaterPressureSp : WaterPressurePoint & SpPoint <abstract>
+
+//////////////////////////////////////////////////////////////////////////
+// Chilled Water Pressure
+//////////////////////////////////////////////////////////////////////////
+
+// Sensor for chilled water leaving pressure
+ChilledWaterLeavingPressureSensor : WaterPressureSensor { chilled, leaving }
+
+// Sensor for chilled water entering pressure
+ChilledWaterEnteringPressureSensor : WaterPressureSensor { chilled, entering }
+
+// Setpoint for chilled water leaving pressure
+ChilledWaterLeavingPressureSp : WaterPressureSp { chilled, leaving }
+
+// Setpoint for chilled water entering pressure
+ChilledWaterEnteringPressureSp : WaterPressureSp { chilled, entering }
+
+//////////////////////////////////////////////////////////////////////////
+// Hot Water Pressure
+//////////////////////////////////////////////////////////////////////////
+
+// Sensor for hot water leaving pressure
+HotWaterLeavingPressureSensor : WaterPressureSensor { hot, leaving }
+
+// Sensor for hot water entering pressure
+HotWaterEnteringPressureSensor : WaterPressureSensor { hot, entering }
+
+// Setpoint for hot water leaving pressure
+HotWaterLeavingPressureSp : WaterPressureSp { hot, leaving }
+
+// Setpoint for hot water entering pressure
+HotWaterEnteringPressureSp : WaterPressureSp { hot, entering }


### PR DESCRIPTION
This PR adds fundamental water system monitoring points to the ph.points library.

## Changes
- **New file**: `water-pressure.xeto` with pressure sensors and setpoints
- **Extended**: `water-flow.xeto` with chilled and hot water flow points

## Details
- Follows existing ph.points inheritance patterns
- Uses established Haystack tagging conventions  
- Non-breaking, additive changes only
- Based on community provided documentation


## Point Types Added
- Water pressure base types and chilled/hot water variants
- Chilled and hot water flow sensors and setpoints

All changes maintain compatibility with existing library structure.

---

## Update from last PR
- Uses entering/leaving naming conventions for both the tags and the spec names themselves