### PR TITLE
Add Valve and Damper base specs with valve/actuator enums

### DIFF
--- a/src/xeto/ph/enums.xeto
+++ b/src/xeto/ph/enums.xeto
@@ -4,6 +4,41 @@
 // Auto-generated 17-Jan-2025
 //
 
+// Control behavior of an actuator.  Determines whether the actuator
+// positions continuously (modulating), snaps between discrete states
+// (twoPosition), or is driven by raise/lower signals without position
+// feedback (floating).
+ActuatorControlAction: Enum {
+  modulating   // continuous proportional positioning (0-100%)
+  twoPosition  // discrete open/closed (binary)
+  floating     // motor driven by raise/lower signals, no position feedback
+}
+
+// Relationship between command signal direction and physical position.
+// The Haystack convention is 0% = closed and 100% = open.  The
+// actuatorDirection tells tools when the raw BAS signal is inverted.
+ActuatorDirection: Enum {
+  directActing   // 0% signal = closed, 100% signal = open
+  reverseActing  // 0% signal = open, 100% signal = closed
+}
+
+// Position an actuator assumes on loss of control signal or power.
+// Applies to both valve and damper actuators.
+ActuatorFailPosition: Enum {
+  failOpen        // actuator drives/springs to fully open
+  failClosed      // actuator drives/springs to fully closed
+  failInPlace     // actuator holds last position (no spring return)
+  failToPosition  // actuator drives to a configurable intermediate position
+}
+
+// Physical mechanism used by the actuator to produce motion.
+ActuatorMechanism: Enum {
+  electricMotor  // gear motor actuator (rotary or linear)
+  pneumatic      // compressed air diaphragm or piston
+  hydraulic      // hydraulic fluid piston
+  solenoid       // electromagnetic coil (linear, typically on/off)
+}
+
 // Status of point's current value reading.  The [ph::PhEntity.curVal] is only available
 // when curStatus is "ok" or "stale".  However a "stale" value should
 // be used with caution since the local system does not have a fresh value.
@@ -519,6 +554,40 @@ PrimaryFunction: Enum {
   wholesaleClubSupercenter <key:"Wholesale Club/Supercenter">
   worshipFacility <key:"Worship Facility">
   zoo <key:"Zoo">
+}
+
+// Valve body construction type
+ValveBodyType: Enum {
+  ball        // quarter-turn spherical closure element
+  butterfly   // quarter-turn rotating disc
+  gate        // linear multi-turn wedge or knife
+  globe       // linear rising-stem plug
+  needle      // fine-adjustment variant of globe
+  plug        // quarter-turn tapered or cylindrical plug
+}
+
+// Functional role of a valve in a piping system
+ValveFunction: Enum {
+  balancing       // proportional flow balancing
+  bypass          // diverts flow around equipment
+  check           // prevents reverse flow (non-return)
+  control         // modulating or two-position BAS control
+  diverting       // splits one inlet to two outlets
+  expansion       // thermal expansion relief
+  isolation       // on/off service isolation
+  mixing          // blends two inlets to one outlet
+  pressureIndependent  // flow-limiting with integral differential pressure control
+  pressureReducing     // downstream pressure regulation
+  relief          // overpressure safety relief
+  safety          // code-required overpressure protection (ASME rated)
+  thermostatic    // self-actuated temperature regulation
+}
+
+// Number of ports on a valve body
+ValvePorts: Enum {
+  twoWay    // single inlet, single outlet
+  threeWay  // two inlets/one outlet or one inlet/two outlets
+  fourWay   // two inlets, two outlets (rare)
 }
 
 // Enumeration of weather conditions

--- a/src/xeto/ph/equip.xeto
+++ b/src/xeto/ph/equip.xeto
@@ -47,6 +47,10 @@ AcEvsePort: EvsePort {
 // hydraulics, or pneumatics.
 Actuator: Equip {
   actuator
+  actuatorFailPosition:  ActuatorFailPosition?
+  actuatorDirection:     ActuatorDirection?
+  actuatorControlAction: ActuatorControlAction?
+  actuatorMechanism:     ActuatorMechanism?
 }
 
 // Air Handling Unit: An enclosure with a fan that delivers air to a space
@@ -174,10 +178,17 @@ Crac: Fcu {
   crac
 }
 
-// Actuator to regulate the flow of air.
-DamperActuator: Actuator {
+// Equipment to regulate the flow of air in ductwork.  Dampers may be
+// manually operated or automated via an actuator.  Non-actuated dampers
+// such as manual balancing dampers, backdraft dampers, and fire dampers
+// use this spec directly.  BAS-controlled dampers use DamperActuator.
+Damper: Equip <abstract> {
   damper
   ductSection: DuctSection?
+}
+
+// Actuator to regulate the flow of air.
+DamperActuator: Actuator & Damper {
 }
 
 // DC Electricity meter.
@@ -481,11 +492,22 @@ Ups: Equip {
   ups
 }
 
-// Actuator to regulate the flow of fluid.
-ValveActuator: Actuator {
+// Equipment to regulate the flow of fluid in piping.  Valves may be
+// manually operated, self-actuated, or automated via an actuator.
+// Non-actuated valves such as manual isolation valves, check valves,
+// pressure-reducing valves, and thermostatic mixing valves use this
+// spec directly.  BAS-controlled valves use ValveActuator.
+Valve: Equip <abstract> {
   valve
-  pipeFluid:   Fluid?
-  pipeSection: PipeSection?
+  valveFunction: ValveFunction?
+  valvePorts:    ValvePorts?
+  valveBodyType: ValveBodyType?
+  pipeFluid:     Fluid?
+  pipeSection:   PipeSection?
+}
+
+// Actuator to regulate the flow of fluid.
+ValveActuator: Actuator & Valve {
 }
 
 // Variable air volume terminal unit.  VAV systems use a constant air


### PR DESCRIPTION
## Summary

Add foundational equipment specs and enum types for valve and actuator modeling in the `ph` library. This introduces abstract base specs for `Valve` and `Damper`, updates `Actuator` with new classification slots, and defines 7 new Enum types (42 values total).

### Equipment Specs

- **`Valve`**: abstract base for all valve equipment (actuated and non-actuated) with slots for `valveFunction`, `valvePorts`, `valveBodyType`, `pipeFluid`, and `pipeSection`
- **`Damper`**: abstract base for all damper equipment with `ductSection` slot
- **`ValveActuator`**: updated to `Actuator & Valve` intersection — inherits both actuator and valve slots
- **`DamperActuator`**: updated to `Actuator & Damper` intersection — inherits both actuator and damper slots
- **`Actuator`**: gains four new optional slots for fail position, direction, control action, and mechanism

### Enum Types

All classifications use `Enum` rather than `Choice` to avoid adding new global marker tags to `PhEntity`.

| Enum | Values | Purpose |
|-|-|-|
| `ValveFunction` | 13 | Piping role (isolation, control, mixing, bypass, check, …) |
| `ValveBodyType` | 6 | Body construction (globe, butterfly, ball, gate, plug, needle) |
| `ValvePorts` | 3 | Port configuration (twoWay, threeWay, fourWay) |
| `ActuatorFailPosition` | 4 | Fail-safe mode (failOpen, failClosed, failInPlace, failToPosition) |
| `ActuatorDirection` | 2 | Signal mapping (directActing, reverseActing) |
| `ActuatorControlAction` | 3 | Control mode (modulating, twoPosition, floating) |
| `ActuatorMechanism` | 4 | Drive type (electricMotor, pneumatic, hydraulic, solenoid) |

### Design Rationale

- **Valve/Actuator separation**: Non-actuated valves (manual isolation, check, PRV, TMV) are common on mechanical schedules but have no representation in Haystack today. The `Valve` abstract base gives them a home without requiring actuator metadata.
- **Intersection types**: `ValveActuator : Actuator & Valve` composes both concerns cleanly — valve body identity from `Valve`, control metadata from `Actuator`.
- **Enum over Choice**: These classifications are descriptive attributes, not functional tags needed for point/equip queries. Using Enum avoids adding 42 new global markers while still providing validated, closed-set values. If any are later deemed important enough for tag-based queries, they can be promoted to Choice.
- **Damper parity**: `Damper` follows the same pattern as `Valve` so that `DamperActuator` gains symmetry and future damper-specific slots have a home.

### Files Changed

- `src/xeto/ph/enums.xeto` — 7 new Enum types in alphabetical order
- `src/xeto/ph/equip.xeto` — `Valve`, `Damper` abstract bases; updated `Actuator`, `ValveActuator`, `DamperActuator`