### PR TITLE
Add boiler point specs

### DIFF
--- a/src/xeto/ph.points/boiler.xeto
+++ b/src/xeto/ph.points/boiler.xeto
@@ -13,10 +13,11 @@ BoilerHeatRunCmd : HeatRunCmd { boiler }
 BoilerHeatRunSensor : HeatRunSensor { boiler }
 
 // Command to permit/prohibit a boiler to run.
-// Used as an interlock with a run command.
+// Enable is used as an interlock with a run command.
 BoilerEnableCmd : HeatEnableCmd { boiler }
 
-// Command for modulating boiler heating capacity from 0% to 100%
+// Command for modulating boiler heating capacity
+// as a percentage from 0% to 100%
 BoilerHeatModulatingCmd : HeatModulatingCmd { boiler }
 
 // Sensor for boiler water level from 0% (empty) to 100% (full)

--- a/src/xeto/ph.points/boiler.xeto
+++ b/src/xeto/ph.points/boiler.xeto
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2026, Project-Haystack
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   12 Feb 2026  Adam Garnhart  Creation
+//
+
+// On/off command to run a boiler
+BoilerHeatRunCmd : HeatRunCmd { boiler }
+
+// Sensor for on/off state of a boiler
+BoilerHeatRunSensor : HeatRunSensor { boiler }
+
+// Command to permit/prohibit a boiler to run.
+// Used as an interlock with a run command.
+BoilerEnableCmd : HeatEnableCmd { boiler }
+
+// Command for modulating boiler heating capacity from 0% to 100%
+BoilerHeatModulatingCmd : HeatModulatingCmd { boiler }
+
+// Sensor for boiler water level from 0% (empty) to 100% (full)
+BoilerWaterLevelSensor : WaterLevelSensor { boiler }
+
+// Sensor for cumulative runtime duration of a boiler
+BoilerRuntimeSensor : RuntimeSensor { boiler }

--- a/src/xeto/ph.points/misc.xeto
+++ b/src/xeto/ph.points/misc.xeto
@@ -109,11 +109,13 @@ RuntimeSensor : NumberPoint & SensorPoint {
   unit: Unit <quantity:"time"> "hr"
 }
 
-// Sensor for liquid level as a percentage from 0% (empty) to 100% (full)
+// Sensor for liquid level as a percentage where
+// 0% indicates empty and 100% indicates full
 LevelSensor : NumberPoint & SensorPoint <abstract> {
   level
-  unit: Unit <fixed> "%"
+  unit: Unit <invariant> "%"
 }
 
-// Sensor for water level as a percentage from 0% (empty) to 100% (full)
+// Sensor for water level as a percentage where
+// 0% indicates empty and 100% indicates full
 WaterLevelSensor : LevelSensor { water }

--- a/src/xeto/ph.points/misc.xeto
+++ b/src/xeto/ph.points/misc.xeto
@@ -108,3 +108,12 @@ RuntimeSensor : NumberPoint & SensorPoint {
   runtime
   unit: Unit <quantity:"time"> "hr"
 }
+
+// Sensor for liquid level as a percentage from 0% (empty) to 100% (full)
+LevelSensor : NumberPoint & SensorPoint <abstract> {
+  level
+  unit: Unit <fixed> "%"
+}
+
+// Sensor for water level as a percentage from 0% (empty) to 100% (full)
+WaterLevelSensor : LevelSensor { water }


### PR DESCRIPTION
## Summary

Add boiler-specific point specs and the abstract base types they require.

This is a clean replacement for #46, rebased on current master which now includes the `Heat*`/`Cool*` run, enable, and modulating base types.

### New abstract base types (`ph.points/misc.xeto`)

| Spec | Parent | Purpose |
|-|-|-|
| `RuntimeSensor` | `NumberPoint & SensorPoint` | Cumulative equipment runtime duration (hours) |
| `LevelSensor` | `NumberPoint & SensorPoint` | Liquid level percentage (0–100%) |
| `WaterLevelSensor` | `LevelSensor` | Water-specific level sensor |

### New global tag (`ph/entity.xeto`)

- `*runtime: Marker` — cumulative time duration tracking how long equipment has been running

### Boiler point specs (`ph.points/boiler.xeto`)

| Spec | Parent | Description |
|-|-|-|
| `BoilerHeatRunCmd` | `HeatRunCmd` | On/off command to run a boiler |
| `BoilerHeatRunSensor` | `HeatRunSensor` | Sensor for on/off state of a boiler |
| `BoilerEnableCmd` | `HeatEnableCmd` | Interlock enable/disable command |
| `BoilerHeatModulatingCmd` | `HeatModulatingCmd` | Burner capacity 0–100% |
| `BoilerWaterLevelSensor` | `WaterLevelSensor` | Boiler water level 0–100% |
| `BoilerRuntimeSensor` | `RuntimeSensor` | Cumulative runtime hours |

### Changes from #46

- Rebased on current master — drops `HeatRunCmd`, `HeatRunSensor`, `CoolRunCmd`, `CoolRunSensor`, `HeatModulatingCmd`, `CoolModulatingCmd` which now exist upstream
- `BoilerEnableCmd` now extends `HeatEnableCmd` (was `EnableCmd`)
- Only adds base types that are genuinely missing: `RuntimeSensor`, `LevelSensor`, `WaterLevelSensor`

Supersedes #46.