### PR TITLE
Add Valve and Damper abstract base specs

### DIFF
--- a/src/xeto/ph/entity.xeto
+++ b/src/xeto/ph/entity.xeto
@@ -1448,6 +1448,11 @@ PhEntity: Entity <abstract> {
   // may provide an interface for setpoint control.
   *thermostat: Marker
 
+  // Self-actuated temperature regulation.  Used as a feature marker on
+  // valves (e.g. thermostatic mixing valve) and other equipment where
+  // temperature drives the control action without an external actuator.
+  *thermostatic: Marker
+
   // Three-phase AC electricity. Power is provided by three AC voltage
   // sources, each separated from the others by a 120-degree phase angle.
   // May have a 4-wire connection with a neutral (Wye) or a 3-wire connection

--- a/src/xeto/ph/equip.xeto
+++ b/src/xeto/ph/equip.xeto
@@ -174,10 +174,17 @@ Crac: Fcu {
   crac
 }
 
-// Actuator to regulate the flow of air.
-DamperActuator: Actuator {
+// Equipment to regulate the flow of air in ductwork.  Dampers may be
+// manually operated or automated via an actuator.  Non-actuated dampers
+// such as manual balancing dampers, backdraft dampers, and fire dampers
+// use this spec directly.  BAS-controlled dampers use DamperActuator.
+Damper: Equip <abstract> {
   damper
   ductSection: DuctSection?
+}
+
+// Actuator to regulate the flow of air.
+DamperActuator: Actuator & Damper {
 }
 
 // DC Electricity meter.
@@ -481,11 +488,19 @@ Ups: Equip {
   ups
 }
 
-// Actuator to regulate the flow of fluid.
-ValveActuator: Actuator {
+// Equipment to regulate the flow of fluid in piping.  Valves may be
+// manually operated, self-actuated, or automated via an actuator.
+// Non-actuated valves such as manual isolation valves, check valves,
+// pressure-reducing valves, and thermostatic mixing valves use this
+// spec directly.  BAS-controlled valves use ValveActuator.
+Valve: Equip <abstract> {
   valve
   pipeFluid:   Fluid?
   pipeSection: PipeSection?
+}
+
+// Actuator to regulate the flow of fluid.
+ValveActuator: Actuator & Valve {
 }
 
 // Variable air volume terminal unit.  VAV systems use a constant air


### PR DESCRIPTION
Add `Valve` and `Damper` as abstract Equip bases so non-actuated valves (manual isolation, check, PRV, TMV) and non-actuated dampers (fire/smoke, backdraft) have a home in the ontology without requiring actuator metadata.

`ValveActuator` becomes `Actuator & Valve` and `DamperActuator` becomes `Actuator & Damper` — intersection types that compose valve/damper identity with actuator control.

Also adds `*thermostatic` global marker to PhEntity. Together with the existing `*pressureIndependent`, these are feature markers that can be layered onto valves freely rather than being enum values (a PICV is `valve, control, pressureIndependent`; a TMV is `valve, mixing, thermostatic`).

Files: `ph/equip.xeto`, `ph/entity.xeto`