### PR TITLE
Add EnumAttr base type and valve/actuator attrs

### DIFF
--- a/src/xeto/ph.attrs/actuator.xeto
+++ b/src/xeto/ph.attrs/actuator.xeto
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2026, Project-Haystack
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   10 Mar 2026  Adam Garnhart  Creation
+//
+
+// Actuator fail position specified by engineer (failOpen, failClosed, etc.)
+ActuatorFailPositionDesignAttr : EnumAttr { design, actuator, val: ActuatorFailPosition }
+
+// Actuator control action from manufacturer (modulating, twoPosition, floating)
+ActuatorControlActionRatedAttr : EnumAttr { rated, actuator, val: ActuatorControlAction }
+
+// Actuator physical mechanism from manufacturer (electricMotor, pneumatic, etc.)
+ActuatorMechanismRatedAttr : EnumAttr { rated, actuator, val: ActuatorMechanism }

--- a/src/xeto/ph.attrs/base.xeto
+++ b/src/xeto/ph.attrs/base.xeto
@@ -16,6 +16,11 @@ DateAttr: Attr <abstract> {
   val: Date      // Date value of the attribute
 }
 
+// Attribute with an enum value type
+EnumAttr: Attr <abstract> {
+  val: Obj       // Enum value of the attribute
+}
+
 // Attribute with a number value type
 NumberAttr: Attr <abstract> {
   val: Number    // Number value of the attribute

--- a/src/xeto/ph.attrs/valve.xeto
+++ b/src/xeto/ph.attrs/valve.xeto
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2026, Project-Haystack
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   10 Mar 2026  Adam Garnhart  Creation
+//
+
+// Valve function specified by engineer (isolation, control, mixing, etc.)
+ValveFunctionDesignAttr : EnumAttr { design, valve, val: ValveFunction }
+
+// Valve port configuration from manufacturer (twoWay, threeWay, fourWay)
+ValvePortsRatedAttr : EnumAttr { rated, valve, val: ValvePorts }
+
+// Valve body construction type from manufacturer (globe, butterfly, ball, etc.)
+ValveBodyTypeRatedAttr : EnumAttr { rated, valve, val: ValveBodyType }

--- a/src/xeto/ph/enums.xeto
+++ b/src/xeto/ph/enums.xeto
@@ -4,6 +4,41 @@
 // Auto-generated 17-Jan-2025
 //
 
+// Control behavior of an actuator.  Determines whether the actuator
+// positions continuously (modulating), snaps between discrete states
+// (twoPosition), or is driven by raise/lower signals without position
+// feedback (floating).
+ActuatorControlAction: Enum {
+  modulating   // continuous proportional positioning (0-100%)
+  twoPosition  // discrete open/closed (binary)
+  floating     // motor driven by raise/lower signals, no position feedback
+}
+
+// Relationship between command signal direction and physical position.
+// The Haystack convention is 0% = closed and 100% = open.  The
+// actuatorDirection tells tools when the raw BAS signal is inverted.
+ActuatorDirection: Enum {
+  directActing   // 0% signal = closed, 100% signal = open
+  reverseActing  // 0% signal = open, 100% signal = closed
+}
+
+// Position an actuator assumes on loss of control signal or power.
+// Applies to both valve and damper actuators.
+ActuatorFailPosition: Enum {
+  failOpen        // actuator drives/springs to fully open
+  failClosed      // actuator drives/springs to fully closed
+  failInPlace     // actuator holds last position (no spring return)
+  failToPosition  // actuator drives to a configurable intermediate position
+}
+
+// Physical mechanism used by the actuator to produce motion.
+ActuatorMechanism: Enum {
+  electricMotor  // gear motor actuator (rotary or linear)
+  pneumatic      // compressed air diaphragm or piston
+  hydraulic      // hydraulic fluid piston
+  solenoid       // electromagnetic coil (linear, typically on/off)
+}
+
 // Status of point's current value reading.  The [ph::PhEntity.curVal] is only available
 // when curStatus is "ok" or "stale".  However a "stale" value should
 // be used with caution since the local system does not have a fresh value.
@@ -519,6 +554,40 @@ PrimaryFunction: Enum {
   wholesaleClubSupercenter <key:"Wholesale Club/Supercenter">
   worshipFacility <key:"Worship Facility">
   zoo <key:"Zoo">
+}
+
+// Valve body construction type
+ValveBodyType: Enum {
+  ball        // quarter-turn spherical closure element
+  butterfly   // quarter-turn rotating disc
+  gate        // linear multi-turn wedge or knife
+  globe       // linear rising-stem plug
+  needle      // fine-adjustment variant of globe
+  plug        // quarter-turn tapered or cylindrical plug
+}
+
+// Functional role of a valve in a piping system.
+// Features like pressureIndependent and thermostatic are layered
+// as separate markers rather than enum values.
+ValveFunction: Enum {
+  balancing        // proportional flow balancing
+  bypass           // diverts flow around equipment
+  check            // prevents reverse flow (non-return)
+  control          // modulating or two-position BAS control
+  diverting        // splits one inlet to two outlets
+  expansion        // thermal expansion relief
+  isolation        // on/off service isolation
+  mixing           // blends two inlets to one outlet
+  pressureReducing // downstream pressure regulation
+  relief           // overpressure safety relief
+  safety           // code-required overpressure protection (ASME rated)
+}
+
+// Number of ports on a valve body
+ValvePorts: Enum {
+  twoWay    // single inlet, single outlet
+  threeWay  // two inlets/one outlet or one inlet/two outlets
+  fourWay   // two inlets, two outlets (rare)
 }
 
 // Enumeration of weather conditions

--- a/src/xeto/ph/equip.xeto
+++ b/src/xeto/ph/equip.xeto
@@ -45,6 +45,7 @@ AcEvsePort: EvsePort & ElecAcEquip
 // hydraulics, or pneumatics.
 Actuator: Equip {
   actuator
+  actuatorDirection: ActuatorDirection?
 }
 
 // Air Handling Unit: An enclosure with a fan that delivers air to a space


### PR DESCRIPTION
Depends on #54.

`EnumAttr` completes the Attr type family alongside StrAttr, NumberAttr, DateAttr.

6 typed attr specs split by whether the engineer or manufacturer provides the value:

- Design: `ValveFunctionDesignAttr`, `ActuatorFailPositionDesignAttr`
- Rated: `ValvePortsRatedAttr`, `ValveBodyTypeRatedAttr`, `ActuatorControlActionRatedAttr`, `ActuatorMechanismRatedAttr`

The test for spec vs attr: does changing this property change which points you need or how you interpret the data? If yes, it belongs on the spec (like `actuatorDirection`). If no, it's nameplate or design data and belongs in ph.attrs.

Files: `ph.attrs/base.xeto`, `ph.attrs/valve.xeto` (new), `ph.attrs/actuator.xeto` (new)